### PR TITLE
Backport features and bug fixes

### DIFF
--- a/api/maintainer.go
+++ b/api/maintainer.go
@@ -47,7 +47,14 @@ func GetMaintainer(c *gin.Context) {
 	if err != nil {
 		msg := fmt.Sprintf("Getting maintainer file for %s", name)
 		c.Error(exterror.Append(err, msg))
-	} else {
-		IndentedJSON(c, 200, maintainer)
+		return
 	}
+	_, err = maintainer.PersonToOrg()
+	if err != nil {
+		msg := fmt.Sprintf("Expanding maintainer file for %s", name)
+		c.Error(exterror.Append(err, msg))
+		return
+	}
+	IndentedJSON(c, 200, maintainer)
+
 }

--- a/model/approval.go
+++ b/model/approval.go
@@ -59,25 +59,32 @@ type Processor func(Feedback, ApprovalOp)
 // MatchAction decides whether to invoke the Processor
 type MatchAction func(*ApprovalRequest, Feedback, set.Set, Processor)
 
-func Approve(request *ApprovalRequest, policy *ApprovalPolicy, p Processor) bool {
+func Approve(request *ApprovalRequest, policy *ApprovalPolicy, p Processor) (bool, error) {
 	authorRequest := *request
 	authorComment := Comment{Author: request.PullRequest.Author}
 	authorRequest.ApprovalComments = []Feedback{&authorComment}
 
 	if titleAction(&authorRequest, &authorComment, p) {
-		return false
+		return false, nil
 	}
 
-	if !policy.AuthorMatch.Match(&authorRequest, p, authorLimitAction, authorRequest.ApprovalComments) {
-		return false
+	inner, err := policy.AuthorMatch.Match(&authorRequest, p, authorLimitAction, authorRequest.ApprovalComments)
+	if err != nil {
+		return false, err
+	}
+	if !inner {
+		return false, nil
 	}
 
-	if policy.AntiMatch.Match(request, p, antiMatch, request.DisapprovalComments) {
-		return false
+	inner, err = policy.AntiMatch.Match(request, p, antiMatch, request.DisapprovalComments)
+	if err != nil {
+		return false, err
+	}
+	if inner {
+		return false, nil
 	}
 
-	success := policy.Match.Match(request, p, approvalAction, request.ApprovalComments)
-	return success
+	return policy.Match.Match(request, p, approvalAction, request.ApprovalComments)
 }
 
 // ApprovalPolicy combines an approval scope (that determines
@@ -142,7 +149,7 @@ type MatcherHolder struct {
 
 // Matcher determines whether the match is successful)
 type Matcher interface {
-	Match(req *ApprovalRequest, proc Processor, a MatchAction, feedback []Feedback) bool
+	Match(req *ApprovalRequest, proc Processor, a MatchAction, feedback []Feedback) (bool, error)
 	GetType() string
 	Validate(m *MaintainerSnapshot) error
 }

--- a/model/maintainer.go
+++ b/model/maintainer.go
@@ -32,14 +32,18 @@ type Person struct {
 }
 
 // Org represents a group, team or subset of users.
-type Org struct {
+type Org interface {
+	GetPeople() (set.Set, error)
+}
+
+type OrgSerde struct {
 	People set.Set `json:"people"  toml:"people"`
 }
 
 // Maintainer represents a MAINTAINERS file.
 type Maintainer struct {
-	RawPeople map[string]*Person `json:"people" toml:"people"`
-	RawOrg    map[string]*Org    `json:"org" toml:"org"`
+	RawPeople map[string]*Person   `json:"people" toml:"people"`
+	RawOrg    map[string]*OrgSerde `json:"org" toml:"org"`
 }
 
 var MaintTypes = set.New("text", "hjson", "toml", "legacy")
@@ -50,4 +54,8 @@ func validateMaintainerConfig(c *MaintainersConfig) error {
 			c.Type, MaintTypes.Keys())
 	}
 	return nil
+}
+
+func (o *OrgSerde) GetPeople() (set.Set, error) {
+	return o.People, nil
 }

--- a/model/matchpolicy_test.go
+++ b/model/matchpolicy_test.go
@@ -38,15 +38,9 @@ func createRequest() *ApprovalRequest {
 		"carol": &Person{Name: "carol"},
 		"dan":   &Person{Name: "dan"},
 	}
-	request.Maintainer.Org = map[string]*Org{
-		"guelph":     &Org{People: map[string]bool{"alice": true, "bob": true}},
-		"ghibelline": &Org{People: map[string]bool{"carol": true, "dan": true}},
-	}
-	request.Maintainer.PersonToOrg = map[string]set.Set{
-		"alice": set.New("guelph"),
-		"bob":   set.New("guelph"),
-		"carol": set.New("ghibelline"),
-		"dan":   set.New("ghibelline"),
+	request.Maintainer.Org = map[string]Org{
+		"guelph":     &OrgSerde{People: map[string]bool{"alice": true, "bob": true}},
+		"ghibelline": &OrgSerde{People: map[string]bool{"carol": true, "dan": true}},
 	}
 	request.PullRequest.Author = lowercase.Create("alice")
 	request.PullRequest.Branch.BaseName = "master"
@@ -77,7 +71,7 @@ func TestAnyoneMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -101,7 +95,7 @@ func TestAuthorPolicy(t *testing.T) {
 	request.Config.Approvals[0].Match = MatcherHolder{Matcher: &author}
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -121,7 +115,7 @@ func TestAuthorPolicy(t *testing.T) {
 	request.Config.Approvals[0].Match = MatcherHolder{Matcher: &author}
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -144,7 +138,7 @@ func TestAnonymousMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -156,7 +150,7 @@ func TestAnonymousMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -179,7 +173,7 @@ func TestAnonymousUserAndGroupMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -191,7 +185,7 @@ func TestAnonymousUserAndGroupMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -210,7 +204,7 @@ func TestIssueAuthorMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = MatcherHolder{&m}
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -221,7 +215,7 @@ func TestIssueAuthorMatch(t *testing.T) {
 	request.Issues = append(request.Issues, &Issue{Author: lowercase.Create("david")})
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -245,7 +239,7 @@ func TestAuthorMatch(t *testing.T) {
 	approvers := set.Empty()
 	author := false
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		} else if op == ValidAuthor {
@@ -262,7 +256,7 @@ func TestAuthorMatch(t *testing.T) {
 	approvers = set.Empty()
 	author = false
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		} else if op == ValidAuthor {
@@ -286,7 +280,7 @@ func TestMaintainersMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -300,7 +294,7 @@ func TestMaintainersMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -323,7 +317,7 @@ func TestEntityGroupMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -337,7 +331,7 @@ func TestEntityGroupMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -360,7 +354,7 @@ func TestEntityIndividualMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -374,7 +368,7 @@ func TestEntityIndividualMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -396,7 +390,7 @@ func TestUsMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -410,7 +404,7 @@ func TestUsMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -432,7 +426,7 @@ func TestThemMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers := set.Empty()
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -446,7 +440,7 @@ func TestThemMatch(t *testing.T) {
 	request.Config.Approvals[0].Match = match
 	approvers = set.Empty()
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		}
@@ -464,7 +458,7 @@ func TestTrueMatch(t *testing.T) {
 	match := MatcherHolder{&TrueMatch{}}
 	request.Config.Approvals[0].Match = match
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
+	success, _ := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
 	if success == false {
 		t.Error("match did not succeed")
 	}
@@ -475,7 +469,7 @@ func TestDisableMatch(t *testing.T) {
 	match := MatcherHolder{&DisableMatch{}}
 	request.Config.Approvals[0].Match = match
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
+	success, _ := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
 	if success == false {
 		t.Error("match did not succeed")
 	}
@@ -486,7 +480,7 @@ func TestFalseMatch(t *testing.T) {
 	match := MatcherHolder{&FalseMatch{}}
 	request.Config.Approvals[0].Match = match
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
+	success, _ := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
 	if success == true {
 		t.Error("match did not fail")
 	}
@@ -497,7 +491,7 @@ func TestNotMatch(t *testing.T) {
 	match := MatcherHolder{&NotMatch{Not: MatcherHolder{&FalseMatch{}}}}
 	request.Config.Approvals[0].Match = match
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
+	success, _ := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
 	if success == false {
 		t.Error("match did not succeed")
 	}
@@ -511,7 +505,7 @@ func TestAndMatch(t *testing.T) {
 			{&TrueMatch{}}}}}
 	request.Config.Approvals[0].Match = match
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
+	success, _ := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
 	if success == true {
 		t.Error("match did not fail")
 	}
@@ -521,7 +515,7 @@ func TestAndMatch(t *testing.T) {
 			{&TrueMatch{}}}}}
 	request.Config.Approvals[0].Match = match
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
+	success, _ = Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
 	if success == false {
 		t.Error("match did not succeed")
 	}
@@ -535,7 +529,7 @@ func TestOrMatch(t *testing.T) {
 			{&FalseMatch{}}}}}
 	request.Config.Approvals[0].Match = match
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
+	success, _ := Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
 	if success == true {
 		t.Error("match did not fail")
 	}
@@ -545,7 +539,7 @@ func TestOrMatch(t *testing.T) {
 			MatcherHolder{&TrueMatch{}}}}}
 	request.Config.Approvals[0].Match = match
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
+	success, _ = Approve(request, policy, func(f Feedback, _ ApprovalOp) {})
 	if success == false {
 		t.Error("match did not succeed")
 	}
@@ -583,7 +577,7 @@ func TestDisapprovalComments(t *testing.T) {
 		}
 	}
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, approverFunc)
+	success, _ := Approve(request, policy, approverFunc)
 	if success == true {
 		t.Error("match did not fail")
 	}
@@ -596,7 +590,7 @@ func TestDisapprovalComments(t *testing.T) {
 	request.ApprovalComments = append(request.ApprovalComments, &Comment{Author: lowercase.Create("carol"), Body: "I approve"})
 	request.DisapprovalComments = request.ApprovalComments
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, approverFunc)
+	success, _ = Approve(request, policy, approverFunc)
 	if success == false {
 		t.Error("match did not succeed")
 	}
@@ -639,7 +633,7 @@ func TestDisapprovalReview(t *testing.T) {
 		}
 	}
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, approverFunc)
+	success, _ := Approve(request, policy, approverFunc)
 	if success == true {
 		t.Error("match did not fail")
 	}
@@ -652,7 +646,7 @@ func TestDisapprovalReview(t *testing.T) {
 	request.ApprovalComments = append(request.ApprovalComments, &Comment{Author: lowercase.Create("carol"), Body: "I approve"})
 	request.DisapprovalComments = request.ApprovalComments
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, approverFunc)
+	success, _ = Approve(request, policy, approverFunc)
 	if success == false {
 		t.Error("match did not succeed")
 	}
@@ -679,7 +673,7 @@ func TestTitleMatch(t *testing.T) {
 	approvers := set.Empty()
 	validTitle := false
 	policy := FindApprovalPolicy(request)
-	success := Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ := Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		} else if op == ValidTitle {
@@ -695,7 +689,7 @@ func TestTitleMatch(t *testing.T) {
 	request.PullRequest.Title = "An experiment"
 	validTitle = false
 	policy = FindApprovalPolicy(request)
-	success = Approve(request, policy, func(f Feedback, op ApprovalOp) {
+	success, _ = Approve(request, policy, func(f Feedback, op ApprovalOp) {
 		if op == Approval {
 			approvers.Add(f.GetAuthor().String())
 		} else if op == ValidTitle {

--- a/model/snapshot.go
+++ b/model/snapshot.go
@@ -18,12 +18,32 @@ See the License for the specific language governing permissions and limitations 
 */
 package model
 
-import (
-	"github.com/capitalone/checks-out/set"
-)
+import "github.com/capitalone/checks-out/set"
 
 type MaintainerSnapshot struct {
-	People      map[string]*Person
-	Org         map[string]*Org
-	PersonToOrg map[string]set.Set
+	People map[string]*Person
+	Org    map[string]Org
+}
+
+func (m *MaintainerSnapshot) PersonToOrg() (map[string]set.Set, error) {
+	mapping := make(map[string]set.Set)
+	for k, v := range m.Org {
+		//value is name of person in the org
+		people, err := v.GetPeople()
+		if err != nil {
+			return nil, err
+		}
+		for name := range people {
+			if _, ok := m.People[name]; !ok {
+				continue
+			}
+			orgs, ok := mapping[name]
+			if !ok {
+				orgs = set.Empty()
+				mapping[name] = orgs
+			}
+			orgs.Add(k)
+		}
+	}
+	return mapping, nil
 }

--- a/remote/github/client.go
+++ b/remote/github/client.go
@@ -64,16 +64,6 @@ func (c *Client) SetClient(client *http.Client) {
 	c.client = client
 }
 
-func (c *Client) AddBranchProtect(owner, name, branch string, ctxs []string) error {
-	uri := fmt.Sprintf(pathBranch, c.base, owner, name, branch)
-	return c.post(uri, ctxs, nil)
-}
-
-func (c *Client) RemoveBranchProtect(owner, name, branch string, ctxs []string) error {
-	uri := fmt.Sprintf(pathBranch, c.base, owner, name, branch)
-	return c.delete(uri, ctxs, nil)
-}
-
 //
 // http request helper functions
 //

--- a/snapshot/maintainer_text.go
+++ b/snapshot/maintainer_text.go
@@ -33,7 +33,7 @@ import (
 func parseMaintainerText(c context.Context, user *model.User, data []byte, r *model.Repo) (*model.Maintainer, error) {
 	m := new(model.Maintainer)
 	m.RawPeople = map[string]*model.Person{}
-	m.RawOrg = map[string]*model.Org{}
+	m.RawOrg = map[string]*model.OrgSerde{}
 
 	buf := bytes.NewBuffer(data)
 	reader := bufio.NewReader(buf)
@@ -131,7 +131,7 @@ func parseMaintainerText(c context.Context, user *model.User, data []byte, r *mo
 
 func addOrg(m *model.Maintainer, item string, name string) error {
 	name = strings.ToLower(name)
-	o := &model.Org{People: map[string]bool{item: true}}
+	o := &model.OrgSerde{People: map[string]bool{item: true}}
 	if _, ok := m.RawOrg[name]; ok {
 		err := fmt.Errorf("Duplicate organization detected %s", name)
 		return badRequest(err)

--- a/snapshot/maintainer_toml.go
+++ b/snapshot/maintainer_toml.go
@@ -59,8 +59,8 @@ func parseMaintainerToml(data []byte) (*model.Maintainer, error) {
 	return m, err
 }
 
-func buildRawOrg(tree *toml.Tree) (map[string]*model.Org, error) {
-	rawOrg := map[string]*model.Org{}
+func buildRawOrg(tree *toml.Tree) (map[string]*model.OrgSerde, error) {
+	rawOrg := map[string]*model.OrgSerde{}
 	o, ok := tree.Get("org").(*toml.Tree)
 	if !ok {
 		return nil, errors.New("Invalid Toml format. Org section is invalid.")
@@ -70,7 +70,7 @@ func buildRawOrg(tree *toml.Tree) (map[string]*model.Org, error) {
 		if !ok {
 			return nil, fmt.Errorf("Invalid toml format. Org %s is invalid.", v)
 		}
-		curOrg := &model.Org{}
+		curOrg := &model.OrgSerde{}
 		pSlice, ok := org.Get("people").([]interface{})
 		if !ok {
 			return nil, fmt.Errorf("Invalid toml format. Org %s people isn't a slice of strings", v)

--- a/store/datastore/datastore.go
+++ b/store/datastore/datastore.go
@@ -42,7 +42,7 @@ import (
 type datastore struct {
 	*sql.DB
 	Migrations set.Set
-	curDB string
+	curDB      string
 }
 
 var once sync.Once
@@ -102,7 +102,7 @@ func pingDatabase(db *sql.DB) (err error) {
 		if err == nil {
 			return
 		}
-		logrus.Infof("database ping failed. retry in 1s")
+		logrus.Infof("database ping failed. retry in 1s. %s", err)
 		time.Sleep(time.Second)
 	}
 	return
@@ -145,7 +145,7 @@ func setupMeddler(driver string) {
 }
 
 const (
-	POSTGRES  = "postgres"
-	MYSQL  = "mysql"
-	SQLITE  = "sqlite3"
+	POSTGRES = "postgres"
+	MYSQL    = "mysql"
+	SQLITE   = "sqlite3"
 )


### PR DESCRIPTION
Backport patches that missed the transition to open source project:

- Lazy loading of teams for `github-team repo-self`. Necessary for organizations with a big number of teams. Otherwise the GitHub abuse filtering is triggered when we fetch all the teams at the same time.
- Bugfix for branch protection on enrolling repository. Fix is needed to correctly enroll repos.