### PR TITLE
Remove pointer-indirection from status webhook response

### DIFF
--- a/remote/github/github_integration_test.go
+++ b/remote/github/github_integration_test.go
@@ -26,10 +26,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-github/github"
 	"github.com/capitalone/checks-out/envvars"
 	"github.com/capitalone/checks-out/exterror"
 	"github.com/capitalone/checks-out/model"
+
+	"github.com/google/go-github/github"
 	"golang.org/x/oauth2"
 )
 
@@ -312,7 +313,7 @@ func testTags(t *testing.T, client *github.Client, repo *github.Repository, bran
 	if len(tags) != 0 {
 		t.Error("Expected zero tags", len(tags))
 	}
-	err = doTag(ctx, client, r, github.String("foo"), branch.Object.SHA)
+	err = doTag(ctx, client, r, "foo", branch.Object.GetSHA())
 	if err != nil {
 		t.Error("Unable to create tags", err)
 	}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -115,7 +115,7 @@ type Remote interface {
 	CreatePR(c context.Context, u *model.User, r *model.Repo, title, head, base, body string) (int, error)
 
 	// MergePR merges the named pull request from the remote system
-	MergePR(c context.Context, u *model.User, r *model.Repo, pullRequest model.PullRequest, approvers []*model.Person, message string, mergeMethod string) (*string, error)
+	MergePR(c context.Context, u *model.User, r *model.Repo, pullRequest model.PullRequest, approvers []*model.Person, message string, mergeMethod string) (string, error)
 
 	// CompareBranches compares two branches for changes
 	CompareBranches(c context.Context, u *model.User, repo *model.Repo, base string, head string, owner string) (model.BranchCompare, error)
@@ -127,7 +127,7 @@ type Remote interface {
 	ListTags(c context.Context, u *model.User, r *model.Repo) ([]model.Tag, error)
 
 	// Tag applies a tag with the specified string to the specified sha
-	Tag(c context.Context, u *model.User, r *model.Repo, tag *string, sha *string) error
+	Tag(c context.Context, u *model.User, r *model.Repo, tag string, sha string) error
 
 	// GetPullRequest returns the pull request associated with a pull request number
 	GetPullRequest(c context.Context, u *model.User, r *model.Repo, number int) (model.PullRequest, error)
@@ -274,7 +274,7 @@ func CreatePR(c context.Context, u *model.User, r *model.Repo, title, head, base
 	return FromContext(c).CreatePR(c, u, r, title, head, base, body)
 }
 
-func MergePR(c context.Context, u *model.User, r *model.Repo, pullRequest model.PullRequest, approvers []*model.Person, message string, mergeMethod string) (*string, error) {
+func MergePR(c context.Context, u *model.User, r *model.Repo, pullRequest model.PullRequest, approvers []*model.Person, message string, mergeMethod string) (string, error) {
 	return FromContext(c).MergePR(c, u, r, pullRequest, approvers, message, mergeMethod)
 }
 
@@ -290,7 +290,7 @@ func ListTags(c context.Context, u *model.User, r *model.Repo) ([]model.Tag, err
 	return FromContext(c).ListTags(c, u, r)
 }
 
-func Tag(c context.Context, u *model.User, r *model.Repo, tag *string, sha *string) error {
+func Tag(c context.Context, u *model.User, r *model.Repo, tag string, sha string) error {
 	return FromContext(c).Tag(c, u, r, tag, sha)
 }
 

--- a/web/merge.go
+++ b/web/merge.go
@@ -35,10 +35,10 @@ func isBehind(c context.Context, user *model.User, repo *model.Repo, branch mode
 }
 
 func doMerge(c context.Context, user *model.User,
-	hook *StatusHook, req *model.ApprovalRequest, policy *model.ApprovalPolicy, mergeMethod string) (*string, error) {
+	hook *StatusHook, req *model.ApprovalRequest, policy *model.ApprovalPolicy, mergeMethod string) (string, error) {
 	approvals, err := buildApprovers(c, user, req)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	var people []*model.Person
 	for id := range approvals.Approvers {
@@ -53,7 +53,7 @@ func doMerge(c context.Context, user *model.User,
 
 	SHA, err := remote.MergePR(c, user, hook.Repo, *req.PullRequest, people, message, mergeMethod)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 	return SHA, nil
 }

--- a/web/status_hook.go
+++ b/web/status_hook.go
@@ -29,10 +29,10 @@ import (
 )
 
 type StatusResponse struct {
-	SHA  *string `json:"sha,omitempty"`
-	Tag  *string `json:"tag,omitempty"`
-	Err  string  `json:"error,omitempty"`
-	Info string  `json:"info,omitempty"`
+	SHA  string `json:"sha,omitempty"`
+	Tag  string `json:"tag,omitempty"`
+	Err  string `json:"error,omitempty"`
+	Info string `json:"info,omitempty"`
 }
 
 func generateError(msg string, err error, v model.PullRequest, slug string,
@@ -167,9 +167,9 @@ func (hook *StatusHook) Process(c context.Context) (interface{}, error) {
 
 			result.Tag = tag
 
-			if tag != nil {
+			if tag != "" {
 				mw.Messages = append(mw.Messages, notifier.MessageInfo{
-					Message: fmt.Sprintf("Tag %s has been added", *tag),
+					Message: fmt.Sprintf("Tag %s has been added", tag),
 					Type:    model.CommentTag,
 				})
 			}


### PR DESCRIPTION
The pointers to strings are unnecessary. To be paranoid I confirmed that git does not allow the empty string as a valid tag.