### PR TITLE
github-team repo-self [orgname] support

### DIFF
--- a/snapshot/maintainer_text.go
+++ b/snapshot/maintainer_text.go
@@ -71,6 +71,7 @@ func parseMaintainerText(c context.Context, user *model.User, data []byte, r *mo
 		}
 		if team, org0 := ParseTeamName(item); len(team) > 0 {
 			if team == SelfTeam {
+				eagerLoad := "github-org " + org0
 				org := org0
 				if org0 == "" {
 					if !r.Org {
@@ -78,11 +79,12 @@ func parseMaintainerText(c context.Context, user *model.User, data []byte, r *mo
 							r.Owner, r.Name)
 						return nil, badRequest(err)
 					}
-					err := addOrg(m, "github-org repo-self", "_")
-					if err != nil {
-						return nil, err
-					}
 					org = r.Owner
+					eagerLoad = "github-org repo-self"
+				}
+				err := addOrg(m, eagerLoad, "_"+org0)
+				if err != nil {
+					return nil, err
 				}
 				teams, err := remote.ListTeams(c, user, org)
 				if err != nil {

--- a/snapshot/snapshot.go
+++ b/snapshot/snapshot.go
@@ -191,20 +191,20 @@ func createSnapshot(c context.Context, user *model.User, caps *model.Capabilitie
 }
 
 // orgLazyLoadCandidate returns true if this github team is eligible
-// for lazy expansion. The special name "_" is introduced
+// for lazy expansion. The special name "_" + orgname is introduced
 // when the "github-team repo-self" is found in the MAINTAINERS
-// file. If "github-team repo-self" is not found then we must use eager
-// evaluation of the GitHub teams in order to populate the
-// model.MaintainerSnapshot.People field.
+// file. The people of the organization are fetched eagerly
+// so that the teams of the organization can be fetched lazily.
 func orgLazyLoadCandidate(people set.Set, orgs map[string]*model.OrgSerde) bool {
-	if _, ok := orgs["_"]; !ok {
-		return false
-	}
 	if len(people) != 1 {
 		return false
 	}
-	team, _ := ParseTeamName(people.Keys()[0])
-	return len(team) > 0
+	team, org := ParseTeamName(people.Keys()[0])
+	if len(team) == 0 {
+		return false
+	}
+	_, ok := orgs["_"+org]
+	return ok
 }
 
 func maintainerToSnapshot(c context.Context, u *model.User, caps *model.Capabilities, r *model.Repo, m *model.Maintainer) (*model.MaintainerSnapshot, error) {


### PR DESCRIPTION
First-class support for github-team repo-self [orgname]. Automatically import all members of the organization including members that are not a part of any team. Load teams on-demand only when needed. Extends current behavior of "github-team repo-self" to "github-team repo-self [orgname]".
    
Closes #6