### PR TITLE
Add 'authoraffirm' feature when multiple committers on pull request.

### DIFF
--- a/model/approval.go
+++ b/model/approval.go
@@ -43,6 +43,7 @@ type ApprovalRequest struct {
 	ApprovalComments    []Feedback
 	DisapprovalComments []Feedback
 	Files               []CommitFile
+	Commits             []Commit
 }
 
 type Feedback interface {

--- a/model/commit.go
+++ b/model/commit.go
@@ -1,0 +1,9 @@
+package model
+
+import "github.com/capitalone/checks-out/strings/lowercase"
+
+type Commit struct {
+	Author  lowercase.String
+	Message string
+	SHA     string
+}

--- a/model/config.go
+++ b/model/config.go
@@ -65,7 +65,8 @@ type MergeConfig struct {
 }
 
 type FeedbackConfig struct {
-	Types []FeedbackType `json:"types,omitempty"`
+	Types        []FeedbackType `json:"types,omitempty"`
+	AuthorAffirm bool           `json:"authoraffirm"`
 }
 
 type CommentConfig struct {
@@ -88,9 +89,9 @@ type DeployConfig struct {
 }
 
 const (
-	maintainers  = "MAINTAINERS"
-	maintType    = "text"
-	deployment   = "DEPLOYMENTS"
+	maintainers = "MAINTAINERS"
+	maintType   = "text"
+	deployment  = "DEPLOYMENTS"
 )
 
 func DefaultConfig() *Config {

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -237,6 +237,7 @@ func TestOldConfigConvert(t *testing.T) {
       "comment"
       "review"
     ]
+    authoraffirm: true
   }
   audit:
   {

--- a/model/feedback.go
+++ b/model/feedback.go
@@ -23,7 +23,8 @@ import "encoding/json"
 
 func DefaultFeedback() FeedbackConfig {
 	return FeedbackConfig{
-		Types: []FeedbackType{CommentType, ReviewType},
+		Types:        []FeedbackType{CommentType, ReviewType},
+		AuthorAffirm: true,
 	}
 }
 

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -135,6 +135,9 @@ type Remote interface {
 	// GetPullRequestFiles returns the changed files associated with a pull request number
 	GetPullRequestFiles(c context.Context, u *model.User, r *model.Repo, number int) ([]model.CommitFile, error)
 
+	// GetPullRequestCommits returns the commits associated with a pull request number
+	GetPullRequestCommits(c context.Context, u *model.User, r *model.Repo, number int) ([]model.Commit, error)
+
 	// GetPullRequestsForCommit returns all pull requests associated with a commit SHA
 	GetPullRequestsForCommit(c context.Context, u *model.User, r *model.Repo, sha *string) ([]model.PullRequest, error)
 
@@ -300,6 +303,10 @@ func GetPullRequest(c context.Context, u *model.User, r *model.Repo, number int)
 
 func GetPullRequestFiles(c context.Context, u *model.User, r *model.Repo, number int) ([]model.CommitFile, error) {
 	return FromContext(c).GetPullRequestFiles(c, u, r, number)
+}
+
+func GetPullRequestCommits(c context.Context, u *model.User, r *model.Repo, number int) ([]model.Commit, error) {
+	return FromContext(c).GetPullRequestCommits(c, u, r, number)
 }
 
 func GetPullRequestsForCommit(c context.Context, u *model.User, r *model.Repo, sha *string) ([]model.PullRequest, error) {

--- a/web/approval_test.go
+++ b/web/approval_test.go
@@ -51,6 +51,7 @@ func TestGenerateStatus(t *testing.T) {
 			AuditApproved:  false,
 			TitleApproved:  false,
 			AuthorApproved: false,
+			AuthorAffirmed: true,
 		}: {
 			status: "error",
 			desc:   "audit chain must be manually approved",
@@ -61,6 +62,7 @@ func TestGenerateStatus(t *testing.T) {
 			AuditApproved:  true,
 			TitleApproved:  false,
 			AuthorApproved: false,
+			AuthorAffirmed: true,
 		}: {
 			status: "error",
 			desc:   "pull request title is blocking merge",
@@ -71,6 +73,7 @@ func TestGenerateStatus(t *testing.T) {
 			AuditApproved:  true,
 			TitleApproved:  true,
 			AuthorApproved: false,
+			AuthorAffirmed: true,
 		}: {
 			status: "error",
 			desc:   "pull request author not allowed",
@@ -81,6 +84,18 @@ func TestGenerateStatus(t *testing.T) {
 			AuditApproved:  true,
 			TitleApproved:  true,
 			AuthorApproved: true,
+			AuthorAffirmed: false,
+		}: {
+			status: "error",
+			desc:   "multiple committers. author must approve PR",
+		},
+
+		&ApprovalInfo{
+			Approved:       false,
+			AuditApproved:  true,
+			TitleApproved:  true,
+			AuthorApproved: true,
+			AuthorAffirmed: true,
 			Disapprovers:   set.New("bob", "frank"),
 		}: {
 			status: "pending",
@@ -92,6 +107,7 @@ func TestGenerateStatus(t *testing.T) {
 			AuditApproved:  true,
 			TitleApproved:  true,
 			AuthorApproved: true,
+			AuthorAffirmed: true,
 			Approvers:      set.New("bob", "frank"),
 		}: {
 			status: "pending",
@@ -103,6 +119,7 @@ func TestGenerateStatus(t *testing.T) {
 			AuditApproved:  true,
 			TitleApproved:  true,
 			AuthorApproved: true,
+			AuthorAffirmed: true,
 		}: {
 			status: "pending",
 			desc:   "no approvals received",

--- a/web/remote.go
+++ b/web/remote.go
@@ -39,6 +39,16 @@ func getPullRequestFiles(c context.Context, user *model.User, repo *model.Repo, 
 	return files, nil
 }
 
+func getPullRequestCommits(c context.Context, user *model.User, repo *model.Repo, num int) ([]model.Commit, error) {
+	commits, err := remote.GetPullRequestCommits(c, user, repo, num)
+	if err != nil {
+		msg := fmt.Sprintf("Error retrieving commits for %s pr %d", repo.Slug, num)
+		err = exterror.Append(err, msg)
+		return nil, err
+	}
+	return commits, nil
+}
+
 func getFeedback(c context.Context,
 	user *model.User,
 	request *model.ApprovalRequest,


### PR DESCRIPTION
Pull request author must approve the pull request when there are committers on the pull request other than the pull request author.