### PR TITLE
Reduce scope of 'authoraffirm' feature

### DIFF
--- a/model/commit.go
+++ b/model/commit.go
@@ -7,4 +7,5 @@ type Commit struct {
 	Committer string
 	Message   string
 	SHA       string
+	Parents   []string
 }

--- a/remote/github/github.go
+++ b/remote/github/github.go
@@ -1110,11 +1110,16 @@ func getPullRequestCommits(ctx context.Context, client *github.Client, r *model.
 	}
 	res := []model.Commit{}
 	for _, c := range commits {
+		parents := []string{}
+		for _, p := range c.Commit.Parents {
+			parents = append(parents, p.GetSHA())
+		}
 		res = append(res, model.Commit{
 			Author:    lowercase.Create(c.Author.GetLogin()),
 			Committer: c.Commit.Committer.GetName(),
 			Message:   c.Commit.GetMessage(),
 			SHA:       c.GetSHA(),
+			Parents:   parents,
 		})
 	}
 	return res, nil

--- a/web/approval.go
+++ b/web/approval.go
@@ -85,10 +85,9 @@ func approve(c context.Context, params HookParams, id int, setStatus bool) (*App
 	return approvePullRequest(c, params, id, &pullRequest, setStatus)
 }
 
-const authorAffirmMsg = "Multiple committers detected on PR branch. " +
-	"Either someone outside of the committers or the PR author must approve the pull request. " +
-	"The PR author can approve to indicate they have reviewed the other commits in the PR. " +
-	"The PR author can approve with a comment on the PR (GitHub Reviews will not work)."
+const authorAffirmMsg = "Someone besides the committers and the PR author should approve the pull request. " +
+	"If this is not possible, the PR author can approve to indicate they have reviewed the other commits in the PR. " +
+	"The PR author must approve with a comment directly on the PR (GitHub Reviews comments will not work)."
 
 var affirmMsgActions = set.New("opened", "reopened", "synchronized")
 

--- a/web/approval.go
+++ b/web/approval.go
@@ -87,8 +87,8 @@ func approve(c context.Context, params HookParams, id int, setStatus bool) (*App
 
 const authorAffirmMsg = "Multiple committers detected on PR branch. " +
 	"Either someone outside of the committers or the PR author must approve the pull request. " +
-	"The PR author approval is to review the commits by the other committers. " +
-	"The PR author can only approve using a pull request comment (GitHub Reviews will not work)."
+	"The PR author can approve to indicate they have reviewed the other commits in the PR. " +
+	"The PR author can approve with a comment on the PR (GitHub Reviews will not work)."
 
 var affirmMsgActions = set.New("opened", "reopened", "synchronized")
 
@@ -394,7 +394,7 @@ func generateStatus(info *ApprovalInfo) (string, string) {
 		}
 	} else if !info.AuthorAffirmed {
 		status = "error"
-		desc = "PR author or non-commit author must approve"
+		desc = "non-committer or PR author must approve"
 	} else if !info.AuditApproved {
 		status = "error"
 		desc = "audit chain must be manually approved"

--- a/web/approval.go
+++ b/web/approval.go
@@ -317,12 +317,12 @@ func calculateApprovalInfo(request *model.ApprovalRequest, policy *model.Approva
 	} else {
 		authAffirm = authorAffirm(request, policy)
 		if !authAffirm {
-			clone := &(*request)
+			clone := *request
 			for _, c := range request.Commits {
-				removeAuthor(c.Author, clone)
+				removeAuthor(c.Author, &clone)
 			}
 			approvers = set.Empty()
-			authAffirm, err = model.Approve(clone, policy,
+			authAffirm, err = model.Approve(&clone, policy,
 				func(f model.Feedback, op model.ApprovalOp) {
 					author := f.GetAuthor().String()
 					switch op {

--- a/web/approval_hook.go
+++ b/web/approval_hook.go
@@ -24,11 +24,12 @@ import (
 	"github.com/capitalone/checks-out/notifier"
 )
 
-func doApprovalHook(c context.Context, hook *ApprovalHook) (*ApprovalOutput, error) {
+func doApprovalHook(c context.Context, hook *ApprovalHook, isApp IsApprover) (*ApprovalOutput, error) {
 	params, err := GetHookParameters(c, hook.HookCommon, hook.Repo.Slug)
 	if err != nil {
 		return nil, err
 	}
+	params.Approval = isApp
 	approvalInfo, err := approve(c, params, hook.Issue.Number, true)
 
 	if err != nil {

--- a/web/approval_test.go
+++ b/web/approval_test.go
@@ -87,7 +87,7 @@ func TestGenerateStatus(t *testing.T) {
 			AuthorAffirmed: false,
 		}: {
 			status: "error",
-			desc:   "multiple committers. author must approve PR",
+			desc:   "PR author or non-commit author must approve",
 		},
 
 		&ApprovalInfo{

--- a/web/approval_test.go
+++ b/web/approval_test.go
@@ -87,7 +87,7 @@ func TestGenerateStatus(t *testing.T) {
 			AuthorAffirmed: false,
 		}: {
 			status: "error",
-			desc:   "PR author or non-commit author must approve",
+			desc:   "non-committer or PR author must approve",
 		},
 
 		&ApprovalInfo{

--- a/web/comment_hook.go
+++ b/web/comment_hook.go
@@ -22,8 +22,9 @@ import (
 	"context"
 	"strings"
 
-	multierror "github.com/mspiegel/go-multierror"
 	"github.com/capitalone/checks-out/model"
+
+	multierror "github.com/mspiegel/go-multierror"
 )
 
 func (hook *CommentHook) Process(c context.Context) (interface{}, error) {
@@ -39,5 +40,5 @@ func doCommentHook(c context.Context, hook *CommentHook) (*ApprovalOutput, error
 	if strings.HasPrefix(hook.Comment, model.CommentPrefix) {
 		return nil, nil
 	}
-	return doApprovalHook(c, &hook.ApprovalHook)
+	return doApprovalHook(c, &hook.ApprovalHook, hook)
 }

--- a/web/github_create.go
+++ b/web/github_create.go
@@ -113,6 +113,7 @@ func createReviewHook(body []byte) (Hook, error) {
 				Slug:  data.Repo.GetFullName(),
 			},
 		},
+		State: lowercase.Create(data.Review.GetState()),
 	}
 
 	return hook, nil

--- a/web/review_hook.go
+++ b/web/review_hook.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (hook *ReviewHook) Process(c context.Context) (interface{}, error) {
-	approvalOutput, e1 := doApprovalHook(c, &hook.ApprovalHook)
+	approvalOutput, e1 := doApprovalHook(c, &hook.ApprovalHook, hook)
 	if e1 != nil {
 		e2 := sendErrorStatus(c, &hook.ApprovalHook, e1)
 		e1 = multierror.Append(e1, e2)


### PR DESCRIPTION
The 'authoraffirm' feature will only be triggered when the following conditions have been met: (1) the pull request has received enough approvals to be accepted as reviewed, (2) the pull request has commit authors that are not the pull request author, (3) removing the approvals made by committers causes the pull request to not be accepted as reviewed.

If all three conditions are met, then a message is reported indicating that more approvers are needed or the pull request author must approve the PR.