### PR TITLE
Allow branch deletion when the final policy disables deletion.

### DIFF
--- a/web/status_hook_test.go
+++ b/web/status_hook_test.go
@@ -728,6 +728,13 @@ func TestEligibleForDeletion(t *testing.T) {
 	if !eligibleForDeletion(request, mw) {
 		t.Error("off policy should be eligible for deletion")
 	}
+	config.Approvals[0] = model.DefaultApprovalPolicy()
+	config.Approvals[0].Merge = &model.MergeConfig{
+		Delete: false,
+	}
+	if !eligibleForDeletion(request, mw) {
+		t.Error("disable deletion should allow other branches to be deleted")
+	}
 	config.Approvals = append(config.Approvals, model.DefaultApprovalPolicy())
 	config.Approvals[0].Scope.Branches = set.New("baz")
 	if eligibleForDeletion(request, mw) {


### PR DESCRIPTION
The initial implementation allows branch deletion only when the final policy in the policy array (the fallback policy) has approval policy "off". This is to ensure that the fallback policy doesn't delete branches willy-nilly.

It is equivalent to have the 'delete' flag disabled in the final policy in the policy array. If we test the 'delete' flag then we also allow for other policies in the final policy other than the "off" policy.