### PR TITLE
'ignoreuimerge' change default from disabled to enabled

### DIFF
--- a/model/commit.go
+++ b/model/commit.go
@@ -9,3 +9,12 @@ type Commit struct {
 	SHA       string
 	Parents   []string
 }
+
+func DefaultCommit() CommitConfig {
+	return CommitConfig{
+		Range:         Head,
+		AntiRange:     Head,
+		TagRange:      Head,
+		IgnoreUIMerge: true,
+	}
+}

--- a/model/config.go
+++ b/model/config.go
@@ -24,7 +24,6 @@ import (
 	"github.com/capitalone/checks-out/envvars"
 	"github.com/capitalone/checks-out/hjson"
 	"github.com/capitalone/checks-out/strings/rxserde"
-
 	"github.com/mspiegel/go-multierror"
 	"github.com/pelletier/go-toml"
 )
@@ -101,6 +100,7 @@ func DefaultConfig() *Config {
 	c.Maintainers.Path = maintainers
 	c.Maintainers.Type = maintType
 	c.Deployment.Path = deployment
+	c.Commit = DefaultCommit()
 	c.Feedback = DefaultFeedback()
 	c.Merge = DefaultMerge()
 	c.Tag = DefaultTag()

--- a/model/config_test.go
+++ b/model/config_test.go
@@ -218,6 +218,13 @@ func TestOldConfigConvert(t *testing.T) {
     }
   ]
   pattern: "LOOKGOOD"
+  commit:
+  {
+    range: "head"
+    antirange: "head"
+    tagrange: "head"
+    ignoreuimerge: true
+  }
   maintainers:
   {
     path: MAINTAINERS


### PR DESCRIPTION
Ignores UI merges made through the GitHub UI for the purposes of resetting the approval count.