### PR TITLE
Go 1.11 compatibility fixes for go test changes

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func startService() {
 
 	handler := router.Load()
 
-	logrus.Infof("Starting %s service on %d", envvars.Env.Branding.ShortName, time.Now().Format(time.RFC1123))
+	logrus.Infof("Starting %s service on %s", envvars.Env.Branding.ShortName, time.Now().Format(time.RFC1123))
 
 	if envvars.Env.Server.Cert != "" {
 		logrus.Fatal(

--- a/router/middleware/access/access.go
+++ b/router/middleware/access/access.go
@@ -34,7 +34,7 @@ func OwnerAdmin(c *gin.Context) {
 
 	perm, err := remote.GetOrgPerm(c, user, owner)
 	if err != nil {
-		log.Warnf("Cannot find org %s/%s. %s", owner, err)
+		log.Warnf("Cannot find org %s. %s", owner, err)
 		c.String(404, "Not Found")
 		c.Abort()
 		return

--- a/web/github_create.go
+++ b/web/github_create.go
@@ -96,7 +96,7 @@ func createReviewHook(body []byte) (Hook, error) {
 		data.PullRequest.GetState())
 	// don't process reviews on closed pull requests
 	if data.PullRequest.GetState() == "closed" {
-		log.Debugf("PR %s is closed -- not processing comments for it any more", data.PullRequest.Title)
+		log.Debugf("PR %s is closed -- not processing comments for it any more", *(data.PullRequest.Title))
 		return nil, nil
 	}
 
@@ -138,7 +138,7 @@ func createCommentHook(body []byte) (Hook, error) {
 		data.Issue.GetState())
 	// don't process comments on closed pull requests
 	if data.Issue.GetState() == "closed" {
-		log.Debugf("PR %s is closed -- not processing comments for it any more", data.Issue.Title)
+		log.Debugf("PR %s is closed -- not processing comments for it any more", *(data.Issue.Title))
 		return nil, nil
 	}
 

--- a/web/login.go
+++ b/web/login.go
@@ -73,7 +73,7 @@ func Login(c *gin.Context) {
 	} else if err == sql.ErrNoRows {
 		err = validateUserAccess(c, tmpuser)
 		if err != nil {
-			log.Warnf("cannot create account for user. %s", tmpuser.Login, err)
+			log.Warnf("cannot create account for user %s. %s", tmpuser.Login, err)
 			c.Redirect(303, "/login?error=no_access_error")
 			return
 		}


### PR DESCRIPTION
Go 1.11 changed `go test` behavior to include running `go vet` as
well.  There were a few format strings being used by various `fmt`
package and package like calls that had either mismatching
argument counts between the format string and args or type mismatch
between the fmt spec and the argument itself.  Fixed them all to
either match type or arg count as appropriate.

These changes are backwards compatible with prior versions of the
go compiler because it is just fixing things that were previously
broken but unnoticed.