### PR TITLE
Add Travis CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Checks-Out
 
+[![Build Status](https://travis-ci.org/capitalone/checks-out.svg?branch=dev)](https://travis-ci.org/capitalone/checks-out)
 [![Join the chat at https://gitter.im/capitalone/checks-out](https://badges.gitter.im/capitalone/checks-out.svg)](https://gitter.im/capitalone/checks-out?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Checks-Out is a simple pull request approval system using GitHub


### PR DESCRIPTION
After converting repo to use Travis CI as a github app, add Travis CI badge to README so state is displayed on project page in github.